### PR TITLE
added option to accept additional paths

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,18 +1,25 @@
 
 var stylus = require('stylus');
 var minimatch = require('minimatch');
+var join = require('path').join;
 
 function plugin (opts) {
   var opts = opts || {};
+  opts.paths = (opts.paths || []).map(absPath);
+
   return function (files, metalsmith, done) {
     var destination = metalsmith.destination();
     var source = metalsmith.source();
     var styles = Object.keys(files).filter(minimatch.filter("*.+(styl|stylus)", {matchBase: true}));
+
     var paths = styles.map(function (path) {
       var ret = path.split('/');
       ret.pop()
       return source + '/' + ret.join('/')
     })
+
+    paths = paths.concat(opts.paths)
+
     styles.forEach(function (file, index, arr) {
       var out = file.split('.');
       out.pop();
@@ -31,3 +38,7 @@ function plugin (opts) {
 }
 
 module.exports = plugin;
+
+function absPath(relative) {
+  return join(process.cwd(), relative);
+}


### PR DESCRIPTION
Currently `@import` and `@require` don't work if your styles are outside of your default source directory (eg `./templates/styles` or `./themes`). This allows you to pass in additional lookup paths for stylus' import:

```
"metalsmith-stylus": {
  "paths": ["templates/styles"]
},
```
