### PR TITLE
Adds fingerprint() function to use alongside metalsmith-fingerprint

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ var stylus = require('stylus');
 var minimatch = require('minimatch');
 var join = require('path').join;
 var nib = require('nib');
+var path = require('path');
 
 function plugin (opts) {
   opts = opts || {};
@@ -11,6 +12,7 @@ function plugin (opts) {
     var destination = metalsmith.destination();
     var source = metalsmith.source();
     var styles = Object.keys(files).filter(minimatch.filter("*.+(styl|stylus)", {matchBase: true}));
+    var fingerprint = metalsmith.metadata().fingerprint;
 
     var paths = styles.map(function (path) {
       var ret = path.split('/');
@@ -32,6 +34,16 @@ function plugin (opts) {
         }
         if(opts.nib) {
           s.use(nib());
+        }
+
+        if (fingerprint) {
+          var absFile = join(source, file).split('/');
+          absFile.pop();
+          absFile = absFile.join('/');
+      
+          s.define('fingerprint', function(name){
+            return path.relative(absFile, join(source, fingerprint[name.string]))
+          });
         }
 
         s.render(function (err, css) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-stylus",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "metalsmith stylus plugin",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Adds a stylus function that wraps the `fingerprint` hash generated from [metalsmith-fingerprint](https://github.com/christophercliff/metalsmith-fingerprint). Useful for background images.