### PR TITLE
Remove nib as hard dependency, allow use of arbitrary stylus plug-ins

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 metalsmith-stylus
 ===============
 [![Build Status](https://travis-ci.org/esundahl/metalsmith-stylus.svg?branch=master)](https://travis-ci.org/esundahl/metalsmith-stylus)
-![Dependency Status](https://david-dm.org/esundahl/metalsmith-stylus.png)
+[![Dependency Status](https://david-dm.org/esundahl/metalsmith-stylus.png)](https://david-dm.org/esundahl/metalsmith-stylus)
 
 A [Stylus](http://learnboost.github.io/stylus/) plugin for Metalsmith.
 

--- a/Readme.md
+++ b/Readme.md
@@ -42,4 +42,22 @@ metalsmith.use(stylus());
 
 ## Options
 
-None yet
+All option keys will be passed to stylus' [`set`](https://learnboost.github.io/stylus/docs/js.html#setsetting-value) method, except [`define`](https://learnboost.github.io/stylus/docs/js.html#definename-node) and [`use`](https://learnboost.github.io/stylus/docs/js.html#usefn).
+
+To use stylus plug-ins like [nib](http://tj.github.io/nib/) or [autoprefixer](https://github.com/jenius/autoprefixer-stylus), add them as array to `use`:
+
+```js
+var stylus = require('metalsmith-stylus');
+var nib = require('nib');
+
+metalsmith.use(stylus({
+	// Set stylus output to compressed
+	compress: true,
+	// Use the 'nib' plug-in
+	use: [nib()],
+	// Inline images as base64
+	define: {
+		url: stylus.url()
+	}
+}));
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,6 @@
 var stylus = require('stylus');
 var minimatch = require('minimatch');
 var join = require('path').join;
-var nib = require('nib');
 
 function plugin (opts) {
   opts = opts || {};
@@ -26,12 +25,18 @@ function plugin (opts) {
       out = out.join('.') + '.css';
       var s = stylus(files[file].contents.toString())
         .set('filename', file);
-        
+
         for (var o in opts) {
+          if (o === 'use' || o === 'define') { continue; }
           s.set(o, opts[o]);
         }
-        if(opts.nib) {
-          s.use(nib());
+        if (opts.use) {
+          opts.use.forEach(function(fn) { s.use(fn); })
+        }
+        if (opts.define) {
+          for (var d in opts.define) {
+            s.define(d, opts.define[d]);
+          }
         }
 
         s.render(function (err, css) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,5 +52,7 @@ function plugin (opts) {
 module.exports = plugin;
 
 function absPath(relative) {
+  var cwd = process.cwd();
+  if (relative.slice(0, cwd.length) === cwd) return relative;
   return join(process.cwd(), relative);
 }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "homepage": "https://github.com/esundahl/metalsmith-stylus",
   "dependencies": {
     "nib": "^1.0.3",
-    "stylus": "^0.47.1",
-    "minimatch": "^0.3.0"
+    "stylus": "^0.52.0",
+    "minimatch": "^2.0.9"
   },
   "devDependencies": {
     "mocha": "^1.20.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-stylus",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "description": "metalsmith stylus plugin",
   "main": "lib/index.js",
   "scripts": {
@@ -21,7 +21,6 @@
   },
   "homepage": "https://github.com/esundahl/metalsmith-stylus",
   "dependencies": {
-    "nib": "^1.0.3",
     "stylus": "^0.52.0",
     "minimatch": "^2.0.9"
   },
@@ -29,8 +28,5 @@
     "mocha": "^1.20.1",
     "metalsmith": "^0.8.1",
     "assert-dir-equal": "^1.0.1"
-  },
-  "optionalDependencies": {
-    "canvas": "^1.1.5"
   }
 }


### PR DESCRIPTION
Allow usage of stylus' "use" and "define" methods, e.g. to load arbitrary
plug-ins like autoprefixer or bootstrap and define functions for URL
replacement, etc.

Bumping npm version to 1.0.0, because this is a breaking change.

Example:
```js
var stylus = require('metalsmith-stylus');
var nib = require('nib');
var autoprefixer = require('autoprefixer-stylus');

metalsmith.use(stylus({
	// Regular option: Set stylus output to compressed
	compress: true,
	// Use the 'nib' and 'autoprefixer' plug-in
	use: [nib(), autoprefixer({ browsers: ['ie 7', 'ie 8'] })],
}));
```