### PR TITLE
Avoid double absolute pathing of filenames.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,5 +47,7 @@ function plugin (opts) {
 module.exports = plugin;
 
 function absPath(relative) {
+  var cwd = process.cwd();
+  if (relative.slice(0, cwd.length) === cwd) return relative;
   return join(process.cwd(), relative);
 }


### PR DESCRIPTION
This had me debugging for hours. In our metalsmith setup we don't use any builtin assumptions about cwd and abspath everything so this was double abspathing the paths we sent it.