### PR TITLE
Write out sourcemap if option is present

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,6 +43,9 @@ function plugin (opts) {
           if (err) throw err;
           delete files[file];
           files[out] = { contents: new Buffer(css) };
+          if (opts.sourcemap) {
+            files[out + '.map'] = { contents: new Buffer(JSON.stringify(s.sourcemap)) };
+          }
         });
     });
     done();


### PR DESCRIPTION
Source maps create a JSON output. Often you will want to set the `basePath` option to the dir where you css file is output. You will also need to add a local workspace which contains your local stylus files and map them to the network resource. https://developer.chrome.com/devtools/docs/workspaces