### PR TITLE
Allow absolute paths not under the current working directory

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,10 @@
 var stylus = require('stylus');
 var minimatch = require('minimatch');
-var join = require('path').join;
+var resolve = require('path').resolve;
 
 function plugin (opts) {
   opts = opts || {};
-  opts.paths = (opts.paths || []).map(absPath);
+  opts.paths = (opts.paths || []).map(function(item) {return resolve(item)});
 
   return function (files, metalsmith, done) {
     var destination = metalsmith.destination();
@@ -53,9 +53,3 @@ function plugin (opts) {
 }
 
 module.exports = plugin;
-
-function absPath(relative) {
-  var cwd = process.cwd();
-  if (relative.slice(0, cwd.length) === cwd) return relative;
-  return join(process.cwd(), relative);
-}

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "minimatch": "^3.0.3"
   },
   "devDependencies": {
-    "mocha": "^1.20.1",
-    "metalsmith": "^0.8.1",
+    "mocha": "^3.2.0",
+    "metalsmith": "^2.3.0",
     "assert-dir-equal": "^1.0.1"
   }
 }


### PR DESCRIPTION
The test for absolute paths does not handle the case when the supplied path does not live under the current working directory.
I've replaced this with a built-in node function to convert paths into absolute paths.

As an example: this causes an issue when you ship metalsmith-stylus as part of a module that is globally installed.
The current working directory will be somewhere in the user home directory (most likely), while the templates are loaded from somewhere in `/usr/lib`