### PR TITLE
Add `file` option to allow compiling from a single entry-point

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ function plugin (opts) {
   return function (files, metalsmith, done) {
     var destination = metalsmith.destination();
     var source = metalsmith.source();
-    var styles = Object.keys(files).filter(minimatch.filter("*.+(styl|stylus)", {matchBase: true}));
+    var styles = Object.keys(files).filter(minimatch.filter(opts.file || "*.+(styl|stylus)", {matchBase: true}));
 
     var paths = styles.map(function (path) {
       var ret = path.split('/');
@@ -27,7 +27,7 @@ function plugin (opts) {
         .set('filename', file);
 
         for (var o in opts) {
-          if (o === 'use' || o === 'define') { continue; }
+          if (o === 'use' || o === 'define' || o === 'file') { continue; }
           s.set(o, opts[o]);
         }
         if (opts.use) {


### PR DESCRIPTION
**Metalsmith config**

```
.use(stylus({
    file: "application.styl",
    paths: [
        "_assets/stylesheets",
    ]
})
```

**application.styl**

```
@import "mixins/**/*"
@import "partials/**/*"
```